### PR TITLE
Revamp chat UI to mirror ChatGPT styling

### DIFF
--- a/frontend/src/components/ChatInterface.tsx
+++ b/frontend/src/components/ChatInterface.tsx
@@ -52,20 +52,25 @@ function cn(...inputs: (string | undefined | null | false)[]): string {
  */
 const Logo = () => {
   return (
-    <a
-      href="#"
-      className="font-normal flex space-x-2 items-center text-sm text-foreground py-1 relative z-20"
-      onClick={(e) => e.preventDefault()}
-    >
-      <div className="h-5 w-6 bg-gradient-to-br from-primary to-cyan-500 rounded-br-lg rounded-tr-sm rounded-tl-lg rounded-bl-sm flex-shrink-0" />
-      <motion.span
-        initial={{ opacity: 0 }}
-        animate={{ opacity: 1 }}
-        className="font-medium text-foreground whitespace-pre"
-      >
-        Incentive AI
-      </motion.span>
-    </a>
+    <div className="pr-2">
+      <div className="flex items-center gap-3">
+        <div className="flex h-10 w-10 items-center justify-center rounded-full bg-gradient-to-br from-emerald-500 to-teal-500 text-white shadow-lg shadow-emerald-500/30">
+          <MessageSquare className="h-5 w-5" />
+        </div>
+        <div className="flex flex-col">
+          <motion.span
+            initial={{ opacity: 0, y: 4 }}
+            animate={{ opacity: 1, y: 0 }}
+            className="text-lg font-semibold text-slate-900 dark:text-white"
+          >
+            Incentive AI
+          </motion.span>
+          <span className="text-xs text-slate-500 dark:text-slate-400">
+            Powered by Augusta Labs
+          </span>
+        </div>
+      </div>
+    </div>
   );
 };
 
@@ -168,20 +173,14 @@ export const ChatInterface: React.FC<ChatInterfaceProps> = ({
   // Sidebar navigation links
   const links = [
     {
-      label: 'New Chat',
-      href: '#',
-      icon: <Plus className="text-foreground h-5 w-5 flex-shrink-0" />,
-      onClick: handleNewChat,
-    },
-    {
       label: 'Chat History',
       href: '#',
-      icon: <MessageSquare className="text-foreground h-5 w-5 flex-shrink-0" />,
+      icon: <MessageSquare className="h-5 w-5" />,
     },
     {
       label: 'Settings',
       href: '#',
-      icon: <Settings className="text-foreground h-5 w-5 flex-shrink-0" />,
+      icon: <Settings className="h-5 w-5" />,
     },
   ];
 
@@ -194,54 +193,69 @@ export const ChatInterface: React.FC<ChatInterfaceProps> = ({
   ];
 
   return (
-    <div 
-      className="flex flex-col md:flex-row w-full h-screen overflow-hidden"
-      style={{
-        backgroundColor: darkMode ? '#000000' : '#ffffff',
-        color: darkMode ? '#ffffff' : '#000000'
-      }}
+    <div
+      className={cn(
+        'flex flex-col md:flex-row w-full h-screen overflow-hidden transition-colors duration-300',
+        darkMode ? 'bg-[#343541] text-slate-100' : 'bg-[#f7f7f8] text-slate-900'
+      )}
     >
       {/* Sidebar */}
       <Sidebar open={open} setOpen={setOpen}>
-        <SidebarBody className="justify-between gap-10">
+        <SidebarBody className="justify-between gap-8">
           <div className="flex flex-col flex-1 overflow-y-auto overflow-x-hidden">
             <Logo />
-            <div className="mt-8 flex flex-col gap-2">
+            <button
+              type="button"
+              onClick={handleNewChat}
+              className={cn(
+                'mt-6 flex items-center justify-center gap-2 rounded-lg border px-3 py-2 text-sm font-medium transition-colors duration-200',
+                darkMode
+                  ? 'border-white/10 bg-[#343541]/60 text-slate-100 hover:bg-white/10'
+                  : 'border-black/10 bg-white text-slate-900 hover:bg-slate-100'
+              )}
+            >
+              <Plus className="h-4 w-4" />
+              New chat
+            </button>
+            <div className="mt-8 text-xs uppercase tracking-wide text-slate-500 dark:text-slate-400/80">
+              Recent
+            </div>
+            <div className="mt-3 flex flex-col gap-1">
               {links.map((link, idx) => (
                 <SidebarLink
                   key={idx}
                   link={link}
-                  {...(link.onClick && {
-                    onClick: link.onClick as React.MouseEventHandler<HTMLAnchorElement>,
-                  })}
+                  className={cn(
+                    'hover:bg-white/10',
+                    !darkMode && 'hover:bg-slate-100 text-slate-700'
+                  )}
                 />
               ))}
             </div>
           </div>
-          <div className="flex flex-col gap-2">
-            {/* Theme Toggle */}
-            <a
-              href="#"
-              onClick={(e) => {
-                e.preventDefault();
-                setDarkMode(!darkMode);
-              }}
-              className="flex items-center justify-start gap-2 group/sidebar py-2 px-2 rounded-md hover:bg-accent transition-colors cursor-pointer"
+          <div className="flex flex-col gap-3">
+            <button
+              type="button"
+              onClick={() => setDarkMode(!darkMode)}
+              className={cn(
+                'flex items-center gap-3 rounded-lg px-3 py-2 text-sm font-medium transition-colors duration-200',
+                darkMode
+                  ? 'text-slate-300 hover:bg-white/10'
+                  : 'text-slate-600 hover:bg-slate-100'
+              )}
             >
-              <div className="relative w-5 h-5 flex-shrink-0">
+              <div className="relative h-5 w-5 flex-shrink-0">
                 <Sun
-                  className={`absolute inset-0 h-5 w-5 text-amber-500 transition-all duration-500 ${
-                    darkMode
-                      ? 'rotate-90 scale-0 opacity-0'
-                      : 'rotate-0 scale-100 opacity-100'
-                  }`}
+                  className={cn(
+                    'absolute inset-0 h-5 w-5 text-amber-400 transition-all duration-500',
+                    darkMode ? 'rotate-90 scale-0 opacity-0' : 'rotate-0 scale-100 opacity-100'
+                  )}
                 />
                 <Moon
-                  className={`absolute inset-0 h-5 w-5 text-slate-400 dark:text-slate-300 transition-all duration-500 ${
-                    darkMode
-                      ? 'rotate-0 scale-100 opacity-100'
-                      : '-rotate-90 scale-0 opacity-0'
-                  }`}
+                  className={cn(
+                    'absolute inset-0 h-5 w-5 text-slate-400 transition-all duration-500',
+                    darkMode ? 'rotate-0 scale-100 opacity-100' : '-rotate-90 scale-0 opacity-0'
+                  )}
                 />
               </div>
               <motion.span
@@ -249,21 +263,37 @@ export const ChatInterface: React.FC<ChatInterfaceProps> = ({
                   display: open ? 'inline-block' : 'none',
                   opacity: open ? 1 : 0,
                 }}
-                className="text-foreground text-sm group-hover/sidebar:translate-x-1 transition duration-150 whitespace-pre inline-block"
+                className={cn(
+                  'text-sm font-medium transition duration-150 whitespace-pre',
+                  darkMode ? 'text-slate-200' : 'text-slate-700'
+                )}
               >
                 Theme
               </motion.span>
-            </a>
+            </button>
             <SidebarLink
               link={{
                 label: 'User Profile',
                 href: '#',
                 icon: (
-                  <div className="h-7 w-7 flex-shrink-0 rounded-full bg-primary flex items-center justify-center">
-                    <User className="h-4 w-4 text-primary-foreground" />
+                  <div
+                    className={cn(
+                      'flex h-8 w-8 items-center justify-center rounded-full',
+                      darkMode
+                        ? 'bg-emerald-500/20 text-emerald-300'
+                        : 'bg-emerald-500/10 text-emerald-600'
+                    )}
+                  >
+                    <User className="h-4 w-4" />
                   </div>
                 ),
               }}
+              className={cn(
+                'border px-3 py-2',
+                darkMode
+                  ? 'border-white/10 bg-[#343541]/60 text-slate-200 hover:bg-white/10'
+                  : 'border-black/10 bg-white text-slate-700 hover:bg-slate-100'
+              )}
             />
           </div>
         </SidebarBody>
@@ -271,24 +301,15 @@ export const ChatInterface: React.FC<ChatInterfaceProps> = ({
 
       {/* Main Content */}
       <div className="flex flex-1 flex-col h-full overflow-hidden">
-        <div className="flex-1 overflow-y-auto p-4 md:p-8">
+        <div className="flex-1 overflow-y-auto px-4 py-6 md:px-8 md:py-10">
           {messages.length === 0 ? (
-            /* Welcome Screen */
-            <div className="flex flex-col items-center justify-center h-full max-w-3xl mx-auto">
+            <div className="mx-auto flex h-full max-w-3xl flex-col items-center justify-center text-center">
               <div className="mb-8">
-                <div 
-                  className="w-16 h-16 rounded-2xl flex items-center justify-center"
-                  style={{
-                    background: 'linear-gradient(135deg, #3b82f6, #8b5cf6)'
-                  }}
-                >
-                  <MessageSquare className="w-8 h-8 text-white" />
+                <div className="flex h-16 w-16 items-center justify-center rounded-2xl bg-gradient-to-br from-emerald-500 to-teal-500 text-white shadow-lg shadow-emerald-500/40">
+                  <MessageSquare className="h-8 w-8" />
                 </div>
               </div>
-              <h1 
-                className="text-3xl md:text-4xl font-bold mb-4 text-center"
-                style={{ color: darkMode ? '#ffffff' : '#000000' }}
-              >
+              <h1 className="text-3xl font-semibold text-slate-900 dark:text-white md:text-4xl">
                 <Typewriter
                   text={['How can I help you today?']}
                   speed={70}
@@ -296,35 +317,27 @@ export const ChatInterface: React.FC<ChatInterfaceProps> = ({
                   showCursor={false}
                 />
               </h1>
-              <div className="grid grid-cols-1 md:grid-cols-2 gap-3 w-full mt-8">
+              <p className="mt-4 text-sm text-slate-500 dark:text-slate-400">
+                Pick a conversation starter below or ask your own question.
+              </p>
+              <div className="mt-8 grid w-full grid-cols-1 gap-3 md:grid-cols-2">
                 {suggestions.map((suggestion, idx) => (
                   <button
                     key={idx}
+                    type="button"
                     onClick={() => setInputValue(suggestion.text)}
-                    className="flex items-center gap-3 p-4 rounded-xl border transition-colors text-left"
-                    style={{
-                      backgroundColor: darkMode ? '#1f1f1f' : '#f5f5f5',
-                      borderColor: darkMode ? '#404040' : '#e5e5e5',
-                      color: darkMode ? '#ffffff' : '#000000'
-                    }}
-                    onMouseEnter={(e) => {
-                      e.currentTarget.style.backgroundColor = darkMode ? '#2a2a2a' : '#e5e5e5';
-                    }}
-                    onMouseLeave={(e) => {
-                      e.currentTarget.style.backgroundColor = darkMode ? '#1f1f1f' : '#f5f5f5';
-                    }}
+                    className="group flex items-center gap-3 rounded-2xl border border-black/10 bg-white/80 p-4 text-left text-slate-700 shadow-sm transition duration-200 hover:-translate-y-0.5 hover:shadow-md dark:border-white/10 dark:bg-[#40414f]/80 dark:text-slate-100"
                   >
-                    <div style={{ color: '#3b82f6' }}>{suggestion.icon}</div>
-                    <span className="text-sm">
-                      {suggestion.text}
+                    <span className="flex h-9 w-9 items-center justify-center rounded-lg bg-emerald-500/10 text-emerald-500 transition duration-200 group-hover:bg-emerald-500/20 dark:bg-emerald-500/20 dark:text-emerald-300">
+                      {suggestion.icon}
                     </span>
+                    <span className="text-sm font-medium leading-tight">{suggestion.text}</span>
                   </button>
                 ))}
               </div>
             </div>
           ) : (
-            /* Chat Messages */
-            <div className="max-w-3xl mx-auto space-y-6">
+            <div className="mx-auto max-w-3xl space-y-6">
               {messages.map((message) => (
                 <div
                   key={message.id}
@@ -334,32 +347,22 @@ export const ChatInterface: React.FC<ChatInterfaceProps> = ({
                   )}
                 >
                   {message.role === 'assistant' && (
-                    <div 
-                      className="w-8 h-8 rounded-lg flex items-center justify-center flex-shrink-0"
-                      style={{
-                        background: 'linear-gradient(135deg, #3b82f6, #8b5cf6)'
-                      }}
-                    >
-                      <MessageSquare className="w-4 h-4 text-white" />
+                    <div className="flex h-8 w-8 flex-shrink-0 items-center justify-center rounded-lg bg-gradient-to-br from-emerald-500 to-teal-500 text-white shadow-md shadow-emerald-500/30">
+                      <MessageSquare className="h-4 w-4" />
                     </div>
                   )}
                   <div
-                    className="rounded-2xl px-4 py-3 max-w-[80%]"
-                    style={{
-                      backgroundColor: message.role === 'user' 
-                        ? (darkMode ? '#ffffff' : '#000000')
-                        : (darkMode ? '#1f1f1f' : '#f5f5f5'),
-                      color: message.role === 'user' 
-                        ? (darkMode ? '#000000' : '#ffffff')
-                        : (darkMode ? '#ffffff' : '#000000')
-                    }}
+                    className={cn(
+                      'max-w-[80%] rounded-2xl border px-4 py-3 text-sm leading-relaxed shadow-sm backdrop-blur',
+                      message.role === 'user'
+                        ? 'border-emerald-200 bg-emerald-50 text-emerald-900 dark:border-emerald-500/40 dark:bg-[#2f3c35] dark:text-emerald-100'
+                        : 'border-black/5 bg-white text-slate-900 dark:border-transparent dark:bg-[#444654] dark:text-slate-100'
+                    )}
                   >
                     {message.role === 'user' ? (
-                      <p className="text-sm whitespace-pre-wrap">
-                        {message.content as string}
-                      </p>
+                      <p className="whitespace-pre-wrap">{message.content as string}</p>
                     ) : message.error ? (
-                      <p className="text-sm" style={{ color: '#ef4444' }}>{message.error}</p>
+                      <p className="text-sm text-red-500">{message.error}</p>
                     ) : (
                       <ResultsDisplay
                         response={message.content as QueryResponse}
@@ -371,33 +374,18 @@ export const ChatInterface: React.FC<ChatInterfaceProps> = ({
                     )}
                   </div>
                   {message.role === 'user' && (
-                    <div 
-                      className="w-8 h-8 rounded-lg flex items-center justify-center flex-shrink-0"
-                      style={{
-                        backgroundColor: darkMode ? '#ffffff' : '#000000'
-                      }}
-                    >
-                      <User className="h-4 w-4" style={{ color: darkMode ? '#000000' : '#ffffff' }} />
+                    <div className="flex h-8 w-8 flex-shrink-0 items-center justify-center rounded-lg bg-emerald-500 text-white shadow-md shadow-emerald-500/30 dark:bg-emerald-500/80">
+                      <User className="h-4 w-4" />
                     </div>
                   )}
                 </div>
               ))}
               {isTyping && (
                 <div className="flex gap-4 justify-start">
-                  <div 
-                    className="w-8 h-8 rounded-lg flex items-center justify-center flex-shrink-0"
-                    style={{
-                      background: 'linear-gradient(135deg, #3b82f6, #8b5cf6)'
-                    }}
-                  >
-                    <MessageSquare className="w-4 h-4 text-white" />
+                  <div className="flex h-8 w-8 flex-shrink-0 items-center justify-center rounded-lg bg-gradient-to-br from-emerald-500 to-teal-500 text-white shadow-md shadow-emerald-500/30">
+                    <MessageSquare className="h-4 w-4" />
                   </div>
-                  <div 
-                    className="rounded-2xl px-4 py-3"
-                    style={{
-                      backgroundColor: darkMode ? '#1f1f1f' : '#f5f5f5'
-                    }}
-                  >
+                  <div className="rounded-2xl border border-black/5 bg-white px-4 py-3 dark:border-transparent dark:bg-[#444654]">
                     <MessageLoading />
                   </div>
                 </div>
@@ -408,33 +396,14 @@ export const ChatInterface: React.FC<ChatInterfaceProps> = ({
         </div>
 
         {/* Input Area */}
-        <div 
-          className="border-t p-4"
-          style={{
-            borderColor: darkMode ? '#404040' : '#e5e5e5',
-            backgroundColor: darkMode ? '#000000' : '#ffffff'
-          }}
-        >
+        <div className="border-t border-black/5 bg-white/80 p-4 dark:border-white/10 dark:bg-[#343541]">
           <div className="max-w-3xl mx-auto">
-            <div 
-              className="flex items-end gap-2 rounded-3xl p-2"
-              style={{
-                backgroundColor: darkMode ? '#1f1f1f' : '#f5f5f5'
-              }}
-            >
-              <button 
-                className="p-2 rounded-full transition-colors"
-                style={{
-                  color: darkMode ? '#a3a3a3' : '#737373'
-                }}
-                onMouseEnter={(e) => {
-                  e.currentTarget.style.backgroundColor = darkMode ? '#2a2a2a' : '#e5e5e5';
-                }}
-                onMouseLeave={(e) => {
-                  e.currentTarget.style.backgroundColor = 'transparent';
-                }}
+            <div className="flex items-end gap-2 rounded-3xl border border-black/10 bg-white px-3 py-3 shadow-sm dark:border-white/10 dark:bg-[#40414f]">
+              <button
+                type="button"
+                className="flex h-10 w-10 items-center justify-center rounded-full text-slate-500 transition-colors duration-200 hover:bg-slate-100 dark:text-slate-300 dark:hover:bg-white/10"
               >
-                <Paperclip className="w-5 h-5" />
+                <Paperclip className="h-5 w-5" />
               </button>
               <textarea
                 ref={textareaRef}
@@ -443,52 +412,30 @@ export const ChatInterface: React.FC<ChatInterfaceProps> = ({
                 onKeyDown={handleKeyDown}
                 placeholder="Message Incentive AI..."
                 rows={1}
-                className="flex-1 bg-transparent resize-none outline-none px-2 py-2 max-h-[200px]"
-                style={{
-                  color: darkMode ? '#ffffff' : '#000000'
-                }}
+                className="flex-1 max-h-[200px] resize-none bg-transparent px-2 py-2 text-sm text-slate-900 outline-none placeholder:text-slate-400 dark:text-slate-100 dark:placeholder:text-slate-500"
               />
-              <button 
-                className="p-2 rounded-full transition-colors"
-                style={{
-                  color: darkMode ? '#a3a3a3' : '#737373'
-                }}
-                onMouseEnter={(e) => {
-                  e.currentTarget.style.backgroundColor = darkMode ? '#2a2a2a' : '#e5e5e5';
-                }}
-                onMouseLeave={(e) => {
-                  e.currentTarget.style.backgroundColor = 'transparent';
-                }}
+              <button
+                type="button"
+                className="flex h-10 w-10 items-center justify-center rounded-full text-slate-500 transition-colors duration-200 hover:bg-slate-100 dark:text-slate-300 dark:hover:bg-white/10"
               >
-                <Mic className="w-5 h-5" />
+                <Mic className="h-5 w-5" />
               </button>
               <button
                 onClick={handleSendMessage}
                 disabled={!inputValue.trim()}
-                className="p-2 rounded-full transition-colors"
-                style={{
-                  backgroundColor: inputValue.trim() 
-                    ? (darkMode ? '#ffffff' : '#000000')
-                    : (darkMode ? '#2a2a2a' : '#e5e5e5'),
-                  color: inputValue.trim() 
-                    ? (darkMode ? '#000000' : '#ffffff')
-                    : (darkMode ? '#a3a3a3' : '#737373'),
-                  cursor: inputValue.trim() ? 'pointer' : 'not-allowed'
-                }}
-                onMouseEnter={(e) => {
-                  if (inputValue.trim()) {
-                    e.currentTarget.style.backgroundColor = darkMode ? '#e5e5e5' : '#404040';
-                  }
-                }}
-                onMouseLeave={(e) => {
-                  if (inputValue.trim()) {
-                    e.currentTarget.style.backgroundColor = darkMode ? '#ffffff' : '#000000';
-                  }
-                }}
+                className={cn(
+                  'flex h-10 w-10 items-center justify-center rounded-full transition-colors duration-200',
+                  inputValue.trim()
+                    ? 'bg-emerald-500 text-white hover:bg-emerald-400'
+                    : 'cursor-not-allowed bg-slate-200 text-slate-400 dark:bg-white/10 dark:text-slate-500'
+                )}
               >
-                <ArrowUp className="w-5 h-5" />
+                <ArrowUp className="h-5 w-5" />
               </button>
             </div>
+            <p className="mt-3 text-center text-xs text-slate-400 dark:text-slate-500">
+              Incentive AI can make mistakes. Consider verifying important information.
+            </p>
           </div>
         </div>
       </div>

--- a/frontend/src/components/Sidebar.tsx
+++ b/frontend/src/components/Sidebar.tsx
@@ -139,7 +139,7 @@ export const DesktopSidebar = ({
   return (
     <motion.div
       className={cn(
-        'h-full px-4 py-4 hidden md:flex md:flex-col bg-background border-r border-border w-[260px] flex-shrink-0',
+        'h-full px-4 py-6 hidden md:flex md:flex-col bg-[#202123] text-slate-200 border-r border-black/20 w-[260px] flex-shrink-0',
         className
       )}
       animate={{
@@ -181,7 +181,7 @@ export const MobileSidebar = ({
       {/* Top bar with hamburger menu */}
       <div
         className={cn(
-          'h-14 px-4 py-4 flex flex-row md:hidden items-center justify-between bg-background border-b border-border w-full'
+          'h-14 px-4 py-4 flex flex-row md:hidden items-center justify-between bg-[#202123] text-slate-200 border-b border-black/20 w-full'
         )}
         {...props}
       >
@@ -205,7 +205,7 @@ export const MobileSidebar = ({
                 ease: 'easeInOut',
               }}
               className={cn(
-                'fixed h-full w-full inset-0 bg-background p-10 z-[100] flex flex-col justify-between',
+                'fixed h-full w-full inset-0 bg-[#202123] text-slate-200 p-10 z-[100] flex flex-col justify-between',
                 className
               )}
             >
@@ -266,7 +266,7 @@ export const SidebarLink = ({
     <a
       href={link.href}
       className={cn(
-        'flex items-center justify-start gap-2 group/sidebar py-2 px-2 rounded-md hover:bg-accent transition-colors cursor-pointer',
+        'flex items-center justify-start gap-2 group/sidebar py-2 px-3 rounded-md text-slate-200/90 hover:bg-white/10 hover:text-white transition-colors cursor-pointer',
         className
       )}
       {...props}
@@ -280,7 +280,7 @@ export const SidebarLink = ({
           display: animate ? (open ? 'inline-block' : 'none') : 'inline-block',
           opacity: animate ? (open ? 1 : 0) : 1,
         }}
-        className="text-foreground text-sm group-hover/sidebar:translate-x-1 transition duration-150 whitespace-pre inline-block !p-0 !m-0"
+        className="text-slate-200/80 text-sm group-hover/sidebar:translate-x-1 transition duration-150 whitespace-pre inline-block !p-0 !m-0"
       >
         {link.label}
       </motion.span>


### PR DESCRIPTION
## Summary
- refresh the chat layout with ChatGPT-inspired colors, gradients, and typography across the sidebar and main conversation area
- add a dedicated New chat button, refined history list styling, and modernized user/assistant message bubbles with hover states
- update the input composer with pill-shaped controls, contextual helper text, and responsive behavior in both light and dark themes

## Testing
- npm run lint *(fails: existing lint violations unrelated to this change)*

------
https://chatgpt.com/codex/tasks/task_e_68e50685317883219bd6f2e15935566e